### PR TITLE
accumulated patches in one PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# This makefile is just used for internal developement.
+# SHOULD NOT be submitted to upstream!!!
+
+# make clean T=<xxx>
+# <xxx> e.g. 
+# buildtools/third_party/libc++:libc++
+# chrome_public_apk
+clean:
+	@echo Start cleaning target: "$(T)"
+	autoninja -v -C out/riscv64 -t clean $(T)
+	@echo Done!
+
+# make ninja T=<xxx>
+# build target and create log file
+ninja:
+	@echo Start building target: "$(T)"
+	-cp ./log ./log.bak
+	autoninja -v -C out/riscv64 $(T) 2>&1 | tee ./log
+	@echo Done!
+
+distclean:
+	rm -rf out/riscv64
+
+gn:
+	gn gen out/riscv64 --args="\
+	target_os=\"android\" \
+	target_cpu=\"riscv64\" \
+	skip_secondary_abi_for_cq=true \
+	android_static_analysis=\"off\" \
+	clang_use_chrome_plugins=false \
+	clang_base_path=\"/aosp/common/wangchen/llvm-build/Release+Asserts\" \
+	clang_use_chrome_plugins=false \
+	default_min_sdk_version=10000"
+

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,14 @@ ninja:
 distclean:
 	rm -rf out/riscv64
 
+# FIXME: "clang_use_chrome_plugins=false" may not be required when we are using
+# clang for Chrome built by ourselves.
 gn:
 	gn gen out/riscv64 --args="\
 	target_os=\"android\" \
 	target_cpu=\"riscv64\" \
 	skip_secondary_abi_for_cq=true \
 	android_static_analysis=\"off\" \
-	clang_use_chrome_plugins=false \
 	clang_base_path=\"/aosp/common/wangchen/llvm-build/Release+Asserts\" \
 	clang_use_chrome_plugins=false \
 	default_min_sdk_version=10000"

--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -43,11 +43,7 @@ if (is_android || is_chromeos) {
 
     # The default to use for android:minSdkVersion for targets that do
     # not explicitly set it.
-    if (current_cpu == "riscv64") {
-      default_min_sdk_version = 29
-    } else {
-      default_min_sdk_version = 24
-    }
+    default_min_sdk_version = 24
 
     # Static analysis can be either "on" or "off" or "build_server". This
     # controls how android lint, error-prone, bytecode checks are run. This

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -147,7 +147,6 @@ android_clang_toolchain("android_clang_mips64el") {
 android_clang_toolchain("android_clang_riscv64") {
   toolchain_args = {
     current_cpu = "riscv64"
-    android64_ndk_api_level = 29
   }
 }
 
@@ -157,7 +156,6 @@ android_clang_toolchain("android_clang_riscv64") {
 android_clang_toolchain("android_clang_riscv32") {
   toolchain_args = {
     current_cpu = "riscv64"
-    android64_ndk_api_level = 29
   }
 }
 

--- a/buildtools/third_party/libc++abi/BUILD.gn
+++ b/buildtools/third_party/libc++abi/BUILD.gn
@@ -65,6 +65,10 @@ source_set("libc++abi") {
     "_LIBCPP_CONSTINIT=constinit",
   ]
 
+  if (is_android && target_cpu == "riscv64") {
+    defines += ["HAVE___CXA_THREAD_ATEXIT_IMPL"]
+  }
+
   configs -= [
     "//build/config/compiler:chromium_code",
     "//build/config/compiler:no_exceptions",


### PR DESCRIPTION
This PR contains 3 patches:

- cb190317fdd76ca3ce32136734f4a4f8046679c2: use args to set default_min_sdk_version
  default_min_sdk_version maybe changed during android developement process, so we should better not fix it in code, for all ARCH (including riscv64).
  for example, let's use `gn --args="default_min_sdk_version=10000" `

- eac959fbcbf17c6a08b38264f6ce174eaf17d753: use __cxa_thread_atexit_impl() from bionic for riscv64
  bionic has implemented __cxa_thread_atexit_impl() and provide it since API level 23, just use it to pass building
  of libc++, otherwise it will report some __thread variables undefined

- 16bbbd3c0e5fccbbc851f5d4ab68fdb5b3970300: added one make file just for internal dev
  To make life easy.
