### PR TITLE
[chrome] Force Pure RISCV64 Support on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,17 @@ distclean:
 	rm -rf out/$(ARCH)
 
 # make gn [ARCH=<xxx>] [CLANG=<xxx>]
+# FIXME(riscv64-android):
+# Before riscv64 introduced into Chromium, every 64-bit ARCH enables its own 32-bit support by default.
+# But for RISCV, Android announced only pure 64-bit would be supported.
+# So for riscv64, to skip the legacy check logic for its 32-bit ABI, skip_secondary_abi_for_cq is enabled by default.
+# Meanwhile, android_static_analysis="off" is mandatory to guarantee disable_android_lint is true to pass gn build.
+# For detailed analysis, please refer to https://github.com/aosp-riscv/chromium/issues/5#issuecomment-1486249579.
 .PHONY: gn
 gn:
 	gn gen out/$(ARCH) --args="\
 	target_os=\"android\" \
 	target_cpu=\"$(ARCH)\" \
-	skip_secondary_abi_for_cq=true \
 	android_static_analysis=\"off\" \
 	clang_base_path=\"$(CLANG)\" \
 	android64_ndk_api_level=29"

--- a/android_webview/BUILD.gn
+++ b/android_webview/BUILD.gn
@@ -24,7 +24,7 @@ import("//tools/resources/generate_resource_allowlist.gni")
 import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
 import("//weblayer/variables.gni")
 
-if (android_64bit_target_cpu && skip_secondary_abi_for_cq) {
+if (android_64bit_target_cpu && defined(android_secondary_abi_toolchain) && skip_secondary_abi_for_cq) {
   assert(current_toolchain != android_secondary_abi_toolchain)
 }
 
@@ -431,19 +431,21 @@ template("webview_alternate_library") {
   }
 }
 
-if (defined(android_secondary_abi_toolchain)) {
-  # Note here that on a given system, the webview-only library needs the same
-  # library name as the browser library, since the system webview factory will
-  # differentiate only by ABI.
-  if (current_toolchain == android_secondary_abi_toolchain) {
-    # This target is the 32-bit WebView library that pairs with a 64-bit
-    # browser. It is suffixed with _64 because its name must match the 64-bit
-    # browser library.
-    webview_alternate_library("monochrome_64") {
-    }
-  } else {
-    # Inverse of above, for the original 32-bit case.
-    webview_alternate_library("monochrome") {
+if (android_64bit_target_cpu) {
+  if (defined(android_secondary_abi_toolchain)) {
+    # Note here that on a given system, the webview-only library needs the same
+    # library name as the browser library, since the system webview factory will
+    # differentiate only by ABI.
+    if (current_toolchain == android_secondary_abi_toolchain) {
+      # This target is the 32-bit WebView library that pairs with a 64-bit
+      # browser. It is suffixed with _64 because its name must match the 64-bit
+      # browser library.
+      webview_alternate_library("monochrome_64") {
+      }
+    } else {
+      # Inverse of above, for the original 32-bit case.
+      webview_alternate_library("monochrome") {
+      }
     }
   }
 } else {

--- a/build/config/android/abi.gni
+++ b/build/config/android/abi.gni
@@ -97,14 +97,14 @@ if (target_cpu == "arm64") {
   android_secondary_abi_cpu = "mipsel"
   android_app_secondary_abi = "mips"
 } else if (target_cpu == "riscv64") {
-  # FIXME(riscv64-android): In origianl design, every 64-bit ARCH defaultly owns itself 32-bit
-  # second abi and will handle 2nd abi here and there.
-  # But for riscv64, we don't want to support riscv32. To not change too much,
-  # currently we just define pseudo 2nd abi here to pass gn build.
-  # A better solution maybe provided to support the case that there is no second
-  # abi, fix me later.
-  android_secondary_abi_cpu = "riscv32"
-  android_app_secondary_abi = "riscv32"
+  # FIXME(riscv64-android):
+  # Before riscv64 introduced into Chromium, every 64-bit ARCH enables its own 32-bit support by default.
+  # But for RISCV, Android announced only pure 64-bit would be supported.
+  # So for riscv64, to skip the legacy check logic for its 32-bit ABI, skip_secondary_abi_for_cq is enabled by default.
+  # Meanwhile, android_static_analysis="off" is mandatory to guarantee disable_android_lint is true to pass gn build.
+  # For detailed analysis, please refer to https://github.com/aosp-riscv/chromium/issues/5#issuecomment-1486249579.
+  # Forces all RISCV APKs/bundles to be 64-bit only since Android RISCV supports riscv64 only.
+  skip_secondary_abi_for_cq = true
 }
 
 if (defined(android_secondary_abi_cpu)) {

--- a/build/toolchain/android/BUILD.gn
+++ b/build/toolchain/android/BUILD.gn
@@ -150,15 +150,6 @@ android_clang_toolchain("android_clang_riscv64") {
   }
 }
 
-# FIXME(riscv64-android): define pseudo toolchain for 2nd abi here, just to pass gn build.
-# Details refer to comments in build/config/android/abi.gni about 2nd abi
-# handling.
-android_clang_toolchain("android_clang_riscv32") {
-  toolchain_args = {
-    current_cpu = "riscv64"
-  }
-}
-
 # Toolchain for creating native libraries that can be used by
 # robolectric_binary targets. It does not emulate NDK APIs nor make available
 # NDK header files.

--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -42,7 +42,7 @@ import("java_sources.gni")
 import("static_initializers.gni")
 import("trichrome.gni")
 
-if (android_64bit_target_cpu && skip_secondary_abi_for_cq) {
+if (android_64bit_target_cpu && defined(android_secondary_abi_toolchain) && skip_secondary_abi_for_cq) {
   assert(current_toolchain != android_secondary_abi_toolchain)
 }
 


### PR DESCRIPTION
Utilize the definition of skip_secondary_abi_for_cq and android_secondary_abi_toolchain directly to support pure RISCV64 on Android.

Before RISCV64 introduced into Chromium, every 64-bit ARCH enables its own 32-bit support by default.
But for RISCV, Android announced only pure 64-bit would be supported.
So for Chromium RISCV64 on Android, one proposed solution based on the commit is to skip the legacy check logic for its 32-bit ABI.